### PR TITLE
Fix parsing of italic correction

### DIFF
--- a/tfm.py
+++ b/tfm.py
@@ -63,10 +63,9 @@ class Tfm_reader:
             d = (b & 0x0f)
 
             b = self.get_byte ()
-
-            # huh? why >> 6 ? 
-            i = (b & 0xfc) >> 6
+            i = (b & 0xfc) >> 2
             tag = (b & 0x3)
+
             rem = self.get_byte ()
 
             # rem is used as index for the ligature table.


### PR DESCRIPTION
`tftopl.web` includes:

```
@d height_index(#)==(tfm[char_info(#)+1] div 16)
@d depth_index(#)==(tfm[char_info(#)+1] mod 16)
@d italic_index(#)==(tfm[char_info(#)+2] div 4)
```

This change updates the italic correction parsing to divide by 4 properly (right-shift 2) instead of the incorrect division by 64 (right-shift 6) that it did previously. (The masks match the bit lengths of each field; tftopl specifies 8 bits for width, 4 for height, 4 for depth, 6 for italic, 2 for tag, and 8 for remainder.)
