### PR TITLE
Quieten fontforge invocation

### DIFF
--- a/mftrace.py
+++ b/mftrace.py
@@ -865,7 +865,7 @@ Quit (0);
         open ('to-ttf.pe', 'w').write (pe_script)
         if options.verbose:
             print 'Fontforge script', pe_script
-        system ("%s -script to-ttf.pe %s %s" % (ff_command,
+        system ("%s -quiet -script to-ttf.pe %s %s" % (ff_command,
               shell_escape_filename (raw_name), shell_escape_filename (options.tfm_file)))
     elif ff_needed and (options.simplify or options.round_to_int or 'ttf' in formats or 'svg' in formats):
         error(_ ("fontforge is not installed; could not perform requested command"))


### PR DESCRIPTION
Hi Han-Wen!

A bunch of patches for mftrace...

This one makes the fontforge invocation be quiet, rather than outputting the somewhat confusing copyright information.  This patch is incompatible with the python3 patch (because an adjacent line has a python3-related change), so one of them will have to be updated before the other can be applied.

Best wishes,

   Julian