### PR TITLE
Quieten fontforge invocation

### DIFF
--- a/mftrace.py
+++ b/mftrace.py
@@ -727,6 +727,10 @@ def get_fontforge_command ():
      and re.search ("-script", open ('pfv').read ()) == None:
         warning ("pfaedit does not support -script.  Install 020215 or later.\nCannot simplify or convert to TTF.\n")
         return ''
+
+    if fontforge_cmd == 'fontforge':
+        fontforge_cmd += ' -quiet'
+
     return fontforge_cmd
 
 def tfm2kpx (tfmname, encoding):


### PR DESCRIPTION
Oh, whoops, the fontforge -quiet invocation in my previous attempt was wrong, as it was activated even when pfaedit was called.  This patch now only add this command-line switch when fontforge is being called.

Best wishes,

Julian