### PR TITLE
Handle tfm files which do not contain coding information

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -96,7 +96,7 @@ clean:
 	rm -f *'~' '#'*
 
 
-TEST_FONTS= ecbi0900 logo10
+TEST_FONTS= ecbi0900 logo10 cmr11
 test:
 	$(foreach a, $(TEST_FONTS), $(PYTHON) mftrace.py --glyphs 65 -V $(a) &&)true
 

--- a/mftrace.py
+++ b/mftrace.py
@@ -140,6 +140,8 @@ def setup_temp  (name):
     global temp_dir
     if not temp_dir:
         temp_dir = TempDirectory (name)
+    else:
+        os.chdir(temp_dir ())
     return temp_dir ()
 
 def popen (cmd, mode = 'r', ignore_error = 0):

--- a/tfm.py
+++ b/tfm.py
@@ -99,7 +99,10 @@ class Tfm_reader:
         
         self.checksum = self.get_number (4)
         self.design_size = self.get_fixp_number ()
-        self.coding = self.get_string ()
+        if self.head_length > 2:
+            self.coding = self.get_string ()
+        else:
+            self.coding = 'UNKNOWN'
 
         self.left =f[(6 + self.head_length) * 4:]
         self.chars = self.extract_chars ()


### PR DESCRIPTION
Hi Han-Wen!

It turns out that converting to Python 3 revealed an ancient issue: the code does not handle TFM files which do not have coding information in a particularly meaningful way, and that causes it to bomb out under Python 3 (see [Debian bug#941885](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=941885)).  In the Python 2 version, the coding string read from the file was meaningless binary, which didn't match any recognised coding system, but in Python 3, the encoding of the string needs to be specified, and so it breaks.

This patch handles this by only reading the coding string if the header is more than 2 words long.

Best wishes,

Julian