### PR TITLE
added r"" to re strings

### DIFF
--- a/README.texi
+++ b/README.texi
@@ -203,7 +203,8 @@ values. Useful simultaneously  with
  Pass the font through FontForge for automatic  simplification and hinting.
 @item --tfmfile=FILE   
  Use @var{file} for the TFM file.  This file is needed to determine at
- what resolution to run MetaFont.
+ what resolution to run MetaFont. If not given, @code{mftrace} tries to find the TFM file 
+ using kpsewhich. If @code{None} is given as an argument, @code{mftrace} does not look for a TFM file.
 @item  -V,--verbose 
  Be verbose: print all commands as they are invoked. This is useful
  for debugging.

--- a/mftrace.py
+++ b/mftrace.py
@@ -314,7 +314,7 @@ def read_encoding (file):
     strng = open (file).read ()
     strng = re.sub ("%.*", '', strng)
     strng = re.sub ("[\n\t \f]+", ' ', strng)
-    m = re.search ('/([^ ]+) \[([^\]]+)\] def', strng)
+    m = re.search (r'/([^ ]+) \[([^\]]+)\] def', strng)
     if not m:
         error ("Encoding file is invalid")
 
@@ -519,7 +519,7 @@ def potrace_path_to_type1_ops (at_file, bitmap_metrics, tfm_wid, magnification):
 
 def read_gf_dims (name, c):
     strng = popen ('%s/gf2pbm -n %d -s %s' % (bindir, c, name)).read ()
-    m = re.search ('size: ([0-9]+)+x([0-9]+), offset: \(([0-9-]+),([0-9-]+)\)', strng)
+    m = re.search (r'size: ([0-9]+)+x([0-9]+), offset: \(([0-9-]+),([0-9-]+)\)', strng)
 
     return tuple (map (int, m.groups ()))
 
@@ -730,9 +730,9 @@ def tfm2kpx (tfmname, encoding):
     pl = popen ("tftopl %s" % (tfmname))
     
     label_pattern = re.compile (
-        "\A   \(LABEL ([DOHC]{1}) ([A-Za-z0-9]*)\)")
+        r"\A   \(LABEL ([DOHC]{1}) ([A-Za-z0-9]*)\)")
     krn_pattern = re.compile (
-        "\A   \(KRN ([DOHC]{1}) ([A-Za-z0-9]*) R (-?[\d\.]+)\)")
+        r"\A   \(KRN ([DOHC]{1}) ([A-Za-z0-9]*) R (-?[\d\.]+)\)")
 
     first = 0
     second = 0

--- a/mftrace.py
+++ b/mftrace.py
@@ -1002,7 +1002,8 @@ Copyright (c) 2005--2006 by
     p.add_option ('--tfmfile',
                   metavar='FILE',
                   action='store',
-                  dest='tfm_file')
+                  dest='tfm_file',
+                  help=_('choose tfm file as base. Default: try to find tfm file on system using kpsewhich. "None" omit searching for tfm file'))
     p.add_option ('-e', '--encoding',
                   metavar="FILE",
                   action='store',
@@ -1334,7 +1335,10 @@ def do_file (filename):
 
     ## setup TFM
     if options.tfm_file:
-        options.tfm_file = os.path.abspath (options.tfm_file)
+        if options.tfm_file == "None":
+            options.tfm_file = None
+        else:
+            options.tfm_file = os.path.abspath (options.tfm_file)
     else:
         tfm_try = find_file (basename + '.tfm')
         if tfm_try:


### PR DESCRIPTION
* modern version of python require r"..." strings if they contain regex specific stuff like `\[` or `\d` (these changes make the warnings disappear).
* allow `--tfmfile None` to avoid looking for a tfm file on the system. This is useful if you want to rerun `mftrace.py` on a font for which you have locally added a character but at the same time a `.tfm`-file for the same font exists on your machine. The original version of `mftrace.py` found the `.tfm`-file and only traced characters already in this `.tfm` but not the eventually new characters. With `--tfmfile None` `mftrace.py` stops looking for `.tfm` files and uses the one locally generated by `metafont`.